### PR TITLE
add wsl support

### DIFF
--- a/sis.el
+++ b/sis.el
@@ -511,7 +511,7 @@ TYPE: TYPE can be 'native, 'emp, 'macism, 'im-select, 'fcitx, 'fcitx5, 'ibus.
     (if (eq system-type 'gnu/linux)
         (setq sis-do-set (lambda(source)
             (sis--ensure-dir
-              (make-process :name "im" :command (list sis--ism source) :connection-type 'pipe ))))
+              (make-process :name "set-input-source" :command (list sis--ism source) :connection-type 'pipe ))))
     t))
    (; fcitx and fcitx5, use the default do-get, set do-set
     (memq ism-type (list 'fcitx 'fcitx5))


### PR DESCRIPTION
由于在wsl的Linux shell中可以直接运行Windows PATH内程序，因此也需要下载并手动放置im-select.exe。

本来想用start-process函数，实践中发现只会在后台开启buffer，并不会生效，所以采用了call-process函数。

在wsl2中测试可用。