### PR TITLE
support for handling spaces at head or tail of inline area with custom function

### DIFF
--- a/sis.el
+++ b/sis.el
@@ -217,7 +217,10 @@ Possible values:
 0: don't delete space
 1: delete 1 space if exists
 'zero: always ensure no space
-'one: always ensure one space")
+'one: always ensure one space
+custom function: the cursor will be moved to the beginning of the inline region,
+                   and the function will be called with an argument which is the
+                   end position of the leading whitespaces in the inline region.")
 
 (defvar sis-inline-tighten-tail-rule 'one
   "Rule to delete tail spaces.
@@ -226,7 +229,10 @@ Possible values:
 0: don't delete space
 1: delete 1 space if exists
 'zero: always ensure no space
-'one: always ensure one space")
+'one: always ensure one space
+custom function: the cursor will be moved to the end of the inline region, and
+                   the function will be called with an argument which is the
+                   beginning of the tailing whitespaces in the inline region.")
 
 (defvar sis-inline-single-space-close nil
   "Single space closes the inline region.")
@@ -1571,7 +1577,10 @@ START: start position of the inline region."
              (; always ensure 1 space
               (eq sis-inline-tighten-tail-rule 'one)
               (delete-region (point) tighten-back-to)
-              (insert-char ?\s))))))
+              (insert-char ?\s))
+             (;; handled by custom function
+              (functionp sis-inline-tighten-tail-rule)
+              (funcall sis-inline-tighten-tail-rule tighten-back-to))))))
 
       ;; move point because of insertion of text adjacent to the saved point
       (when (eq sis-inline-tighten-tail-rule 'one)
@@ -1595,7 +1604,11 @@ START: start position of the inline region."
              (; always ensure 1 space
               (eq sis-inline-tighten-head-rule 'one)
               (delete-region (point) tighten-fore-to)
-              (insert-char ?\s))))))))
+              (insert-char ?\s))
+             (; handled by custom function
+              (functionp sis-inline-tighten-head-rule)
+              (funcall sis-inline-tighten-head-rule tighten-fore-to))
+             ))))))
   (delete-overlay sis--inline-overlay)
   (setq sis--inline-overlay nil)
   (pcase sis--inline-lang


### PR DESCRIPTION
With this PR, we can handle the spaces by custom function.

For instance, when the character preceding the inline area is a Chinese punctuation mark, remove all spaces; otherwise, leave them unchanged.

```elisp
(setq sis-inline-tighten-head-rule
        (lambda (tighten-fore-to)
          (when (memq (char-before) '(?， ?。 ?？ ?！ ?； ?：))
            (delete-region (point) tighten-fore-to))))
```