### PR TITLE
Spacemacs hybrid mode support

### DIFF
--- a/README.org
+++ b/README.org
@@ -227,8 +227,9 @@ its all in English.
 #+END_SRC
 
 Tips:
-1. For ~spacemacs~, if it works in the ~hybrid~ mode, some of the ~evil~ related
-   features may not work. Change to ~vim~ mode instead.
+1. For ~spacemacs~ users, if you are using ~hybrid~ mode, you might need to add
+   ~evil-hybrid-state-exit-hook~ to ~sis-respect-evil-hooks~ and
+   ~evil-hybrid-state-entry-hook~ to ~sis-context-hooks~.
 2. Make sure your ISM is availabe (in your ~$PATH~) before call ~sis~ command.
 
 **  About /inline english mode/

--- a/README.zh.org
+++ b/README.zh.org
@@ -192,7 +192,9 @@ brew install macism
 #+END_SRC
 
 提示：
-1. 对于 ~spacemacs~，如果在 ~hybrid~ 模式下工作，某些与 ~evil~ 相关的功能可能无法正常工作。请改用 ~vim~ 模式。
+1. 对于 ~spacemacs~ 用户，如果你使用 ~hybrid~ 模式，你可能需要将
+   ~evil-hybrid-state-exit-hook~ 添加至 ~sis-respect-evil-hooks~ ，将
+   ~evil-hybrid-state-entry-hook~ 添加至 ~sis-context-hooks~.
 2. 在调用 ~sis~ 命令之前，请确保你的 ISM 可用（在你的 ~$PATH~ 中）。
 
 ** 关于 /内联英文模式/


### PR DESCRIPTION
1. 允许自定义 respect mode 里 `sis-set-english` 绑定的 hook
2. `sis-context-triggers` 只在识别 Doom 且 org module 开启后才添加 `+org/*` 的 hook