### PR TITLE
Add Japanese Hiragana/Katakana to sis-other-pattern

### DIFF
--- a/sis.el
+++ b/sis.el
@@ -49,7 +49,7 @@ Should accept a string which is the id of the input source.")
   "Input source for english.")
 
 (defvar sis-other-pattern
-  "[\u4E00-\u9FFF\u3400-\u4DBF\u3000-\u303F\uFF00-\uFFEF]"
+  "[\u4E00-\u9FFF\u3400-\u4DBF\u3000-\u303F\uFF00-\uFFEF\u3040-\u309F\u30A0-\u30FF]"
   "Pattern to identify a character as other lang.
 
 Default value is CJK characters and punctuations.")


### PR DESCRIPTION
## About

- Add Japanese Hiragana and Katakana to `sis-other-pattern`
    - [Hiragana](https://www.unicode.org/charts/PDF/U3040.pdf)
    - [Katakana](https://www.unicode.org/charts/PDF/U30A0.pdf)

## Screencast

- I'm using `sis` with Japanese language

https://github.com/user-attachments/assets/c8b99c0a-96be-42f2-a4a4-277496780990

## Sample configurations

```elisp
(use-package sis
  :ensure t
  :config
  (setq sis-other-cursor-color "red")

  (sis-ism-lazyman-config
   "com.apple.keylayout.ABC"
   "com.apple.inputmethod.Kotoeri.RomajiTyping.Japanese") ;; default IME of macOS 15.3.2
  (sis-global-cursor-color-mode t)
  (sis-global-respect-mode t)
  (sis-global-context-mode t)
  (sis-global-inline-mode t))
```