### PR TITLE
fix: describe-key on override prefix keys shows default help

### DIFF
--- a/sis.el
+++ b/sis.el
@@ -799,6 +799,18 @@ Possible values: \\='normal, \\='prefix, \\='sequence.")
   (unwind-protect (apply fn args)
     (sis--prefix-override-recap-do)))
 
+(defvar sis--prefix-override-help-fns
+  '(help--read-key-sequence describe-key describe-key-briefly)
+  "Functions advised to bypass the prefix override for key help.")
+
+(defun sis--prefix-override-help-advice (fn &rest args)
+  "Advice for FN reading or describing a key sequence with ARGS.
+
+The advice is needed, so that sequences like \\`C-x C-f' are read and
+looked up as a whole, like the default `describe-key' behavior."
+  (let ((sis--prefix-override-map-enable nil))
+    (apply fn args)))
+
 (defun sis--prefix-override-handler (arg)
   "Prefix key handler with ARG."
   (interactive "P")
@@ -1091,7 +1103,12 @@ Possible values: \\='normal, \\='prefix, \\='sequence.")
        (sis--prefix-override-recap-do)
        (dolist (trigger sis-prefix-override-recap-triggers)
          (advice-add trigger :around
-                     #'sis--prefix-override-recap-advice)))))
+                     #'sis--prefix-override-recap-advice))
+
+       ;; keep default behavior when a command reads or describes a key
+       ;; sequence for help, e.g. `describe-key' (C-h k)
+       (dolist (fn sis--prefix-override-help-fns)
+         (advice-add fn :around #'sis--prefix-override-help-advice)))))
    ;; turn off the mode
    ((not sis-global-respect-mode)
     (sis--try-disable-auto-refresh-mode)
@@ -1126,7 +1143,9 @@ Possible values: \\='normal, \\='prefix, \\='sequence.")
                 emulation-mode-map-alists))
     (setq sis--prefix-override-map-enable nil)
     (dolist (trigger sis-prefix-override-recap-triggers)
-      (advice-remove trigger #'sis--prefix-override-recap-advice)))))
+      (advice-remove trigger #'sis--prefix-override-recap-advice))
+    (dolist (fn sis--prefix-override-help-fns)
+      (advice-remove fn #'sis--prefix-override-help-advice)))))
 
 (defun sis--try-disable-auto-refresh-mode ()
   "Try to disable auto refresh mode."


### PR DESCRIPTION
## Problem

When `sis-global-respect-mode` is enabled, prefix keys such as `C-x`, `C-c`, `C-h`, `C-r` and `M-SPC` are bound to `sis--prefix-override-handler` through `emulation-mode-map-alists`.

This breaks key help. After `C-h k` (`describe-key`), typing a sequence that starts with one of these prefixes (for example `C-x C-f`) shows the help of `sis--prefix-override-handler` instead of the real command. In the normal command loop the handler re-injects the key and lets the real keymap take over, but `read-key-sequence` just resolves `C-x` to the handler and stops there. `C-h c` (`describe-key-briefly`) has the same problem.

## Solution

Temporarily disable the prefix override (`sis--prefix-override-map-enable`) while a key-help command reads and looks up a key sequence, by advising `help--read-key-sequence`, `describe-key` and `describe-key-briefly`.

Both the reading step and the following binding lookup must ignore the override, and they need separate advices:

- The key sequence is read inside the `interactive` form, which runs before the `:around` advice body of `describe-key` / `describe-key-briefly` takes effect. So the read is not covered by advising those commands; advising `help--read-key-sequence` covers it instead.
- The binding lookup (`key-binding`) runs in the command body, so it is covered by advising `describe-key` and `describe-key-briefly`.

The advices are added when `sis-global-respect-mode` is turned on and removed when it is turned off. Normal command-loop behavior (input-source switching on prefix keys) is unchanged.

With this change `C-h k C-x C-f` reports `find-file`, matching the default Emacs behavior.

## My Setting

```lisp
(sis-ism-lazyman-config
 "com.apple.keylayout.ABC"
 "com.google.inputmethod.Japanese.base")
(sis-global-respect-mode 1)
(sis-global-cursor-color-mode 1)
```

## Environment

- Emacs 30.2
