### PR TITLE
refactor: remove obsolete respect prefix plumbing

### DIFF
--- a/README.org
+++ b/README.org
@@ -280,7 +280,6 @@ Note:
 | ~sis-respect-restore-triggers~                  | Additional trigger to restore input source             | ~nil~                  |
 | ~sis-respect-minibuffer-triggers~               | Commands trigger to set input source in minibuffer     | see variable doc       |
 | ~sis-prefix-override-keys~                      | Prefix keys to be respected                            | ~'("C-c" "C-x" "C-h")~ |
-| ~sis-prefix-override-recap-triggers~            | Functions trigger the recap of the prefix override     | see variable doc       |
 | ~sis-prefix-override-buffer-disable-predicates~ | Predicates on buffers to disable prefix overriding     | see variable doc       |
 |-------------------------------------------------+--------------------------------------------------------+------------------------|
 

--- a/README.zh.org
+++ b/README.zh.org
@@ -243,7 +243,6 @@ english text<spc><RET>中文~ ，无需手动切换输入法。
 | ~sis-respect-restore-triggers~                  | 额外的恢复输入源的触发器                  | ~nil~                  |
 | ~sis-respect-minibuffer-triggers~               | 在迷你缓冲区中设置输入源的命令触发器      | 见变量文档             |
 | ~sis-prefix-override-keys~                      | 需要被适应的前缀键                        | ~'("C-c" "C-x" "C-h")~ |
-| ~sis-prefix-override-recap-triggers~            | 触发前缀覆盖重新捕获的函数                | 见变量文档             |
 | ~sis-prefix-override-buffer-disable-predicates~ | 用于禁用前缀覆盖的缓冲区谓词              | 见变量文档             |
 |-------------------------------------------------+-------------------------------------------+------------------------|
 

--- a/sis.el
+++ b/sis.el
@@ -719,16 +719,13 @@ way."
 ;; Following codes are mainly about respect mode
 ;;
 
-(defvar sis--prefix-override-map-alist nil
-  "Map alist for override.")
+(defvar sis--prefix-override-saved-bindings nil
+  "Saved input-decode bindings replaced by respect mode.")
 
 (defvar sis--prefix-handle-stage 'normal
   "Processing state of the prefix key.
 
-Possible values: \\='normal, \\='prefix, \\='sequence.")
-
-(defvar sis--buffer-before-prefix nil
-  "Current buffer before prefix.")
+Possible values: \\='normal, \\='sequence.")
 
 (defvar sis--buffer-before-command nil
   "Current buffer before prefix.")
@@ -744,9 +741,6 @@ Possible values: \\='normal, \\='prefix, \\='sequence.")
 
 (defvar sis--respect-force-restore nil
   "Force restore after command finishes.")
-
-(defvar sis--prefix-override-order -1000
-  "Order of the prefix override in `emulation-mode-map-alists'.")
 
 (defun sis--respect-go-english-advice (&rest _)
   "Advice for `sis-respect-go-english-triggers'."
@@ -787,12 +781,41 @@ Possible values: \\='normal, \\='prefix, \\='sequence.")
   (when (local-variable-p 'sis--prefix-override-map-enable)
     (kill-local-variable 'sis--prefix-override-map-enable)))
 
+(defun sis--prefix-override-make-translation (key)
+  "Return an input-decode translation for KEY."
+  (let ((translated-key (vconcat key)))
+    (lambda (&optional _prompt)
+      (when (and sis--prefix-override-map-enable
+                 (not (eq sis--prefix-handle-stage 'sequence)))
+        (setq sis--prefix-handle-stage 'sequence)
+        (sis--save-to-buffer)
+        (setq sis--for-buffer-locked t)
+        (sis--set-english)
+        (when sis-log-mode
+          (message "Input source: [%s] (saved) => [%s]."
+                   sis--for-buffer sis-english-source)))
+      translated-key)))
+
+(defun sis--prefix-override-install ()
+  "Install prefix override translations."
+  (unless sis--prefix-override-saved-bindings
+    (dolist (prefix sis-prefix-override-keys)
+      (let* ((key (kbd prefix))
+             (binding (lookup-key input-decode-map key)))
+        (push (cons key (unless (numberp binding) binding))
+              sis--prefix-override-saved-bindings)
+        (define-key input-decode-map key
+          (sis--prefix-override-make-translation key))))))
+
+(defun sis--prefix-override-uninstall ()
+  "Restore input-decode bindings replaced by respect mode."
+  (dolist (entry sis--prefix-override-saved-bindings)
+    (define-key input-decode-map (car entry) (cdr entry)))
+  (setq sis--prefix-override-saved-bindings nil))
+
 (defun sis--prefix-override-recap-do ()
   "Recap prefix key override."
-  (add-to-ordered-list
-   'emulation-mode-map-alists
-   'sis--prefix-override-map-alist
-   sis--prefix-override-order))
+  (sis--prefix-override-install))
 
 (defun sis--prefix-override-recap-advice (fn &rest args)
   "Advice for FN of `prefix-override-recap-triggers' with ARGS."
@@ -810,18 +833,6 @@ The advice is needed, so that sequences like \\`C-x C-f' are read and
 looked up as a whole, like the default `describe-key' behavior."
   (let ((sis--prefix-override-map-enable nil))
     (apply fn args)))
-
-(defun sis--prefix-override-handler (arg)
-  "Prefix key handler with ARG."
-  (interactive "P")
-  ;; Restore the prefix arg
-  (setq prefix-arg arg)
-  (prefix-command-preserve-state)
-  ;; Push the key back on the event queue
-  (setq unread-command-events
-        (append (mapcar (lambda (e) (cons t e))
-                        (listify-key-sequence (this-command-keys)))
-                unread-command-events)))
 
 (defun sis--respect-focus-change-advice ()
   "Advice for `after-focus-change-function'."
@@ -862,38 +873,7 @@ looked up as a whole, like the default `describe-key' behavior."
              (this-command-keys)
              sis--real-this-command
              (current-buffer)
-             sis--prefix-override-map-enable))
-
-  (pcase sis--prefix-handle-stage
-    ;; current is normal stage
-    ('normal
-     (cond
-      ;; not prefix key
-      ((not (eq sis--real-this-command #'sis--prefix-override-handler))
-       t)
-
-      ;; for prefix key
-      ((eq sis--real-this-command #'sis--prefix-override-handler)
-
-       ;; go to pre@[prefix] directly
-       (when sis-log-mode
-         (message
-          "[%s] is a prefix key, short circuit to prefix phase."
-          (this-command-keys)))
-       (setq sis--prefix-handle-stage 'prefix)
-       (sis--respect-pre-command-handler))))
-    ;; current is prefix stage
-    ('prefix
-     (setq sis--prefix-override-map-enable nil)
-     (setq sis--buffer-before-prefix (current-buffer))
-     (sis--save-to-buffer)
-     (setq sis--for-buffer-locked t)
-     (sis--set-english)
-     (when sis-log-mode
-       (message "Input source: [%s] (saved) => [%s]."
-                sis--for-buffer sis-english-source)))
-    ;; current is sequence stage
-    ('sequence t)))
+             sis--prefix-override-map-enable)))
 
 (defvar sis-prefix-override-buffer-disable-predicates
   (list 'minibufferp
@@ -982,26 +962,13 @@ looked up as a whole, like the default `describe-key' behavior."
              (current-buffer)
              sis--prefix-override-map-enable))
   (pcase sis--prefix-handle-stage
-    ;; current is prefix stage
-    ('prefix
-     (setq sis--prefix-handle-stage 'sequence))
     ;; current is sequence stage
     ('sequence
-     (cond
-      ;; still in progress
-      ((minibufferp)
-       (setq sis--prefix-handle-stage 'sequence))
-      ;; key sequence is canceled
-      ((not sis--real-this-command)
-       (when sis-log-mode (message "Key sequence canceled."))
-       (setq sis--respect-force-restore t)
-       (sis--to-normal-stage))
-
-      ;; end key sequence
-      (t
+     ;; A command may keep reading in the minibuffer.
+     (unless (minibufferp)
        (when sis-log-mode (message "Key sequence ended."))
        (setq sis--respect-force-restore t)
-       (sis--to-normal-stage))))
+       (sis--to-normal-stage)))
     ;; current is normal stage
     ('normal
      (sis--to-normal-stage))))
@@ -1089,18 +1056,8 @@ looked up as a whole, like the default `describe-key' behavior."
          ;; Don't use :filter-return, advice may not run when trigger has error.
          (advice-add trigger :around #'sis--respect-restore-advice))
 
-       ;; set english when prefix key pressed
-       (setq sis--prefix-override-map-alist
-             `((sis--prefix-override-map-enable
-                .
-                ,(let ((keymap (make-sparse-keymap)))
-                   (dolist (prefix sis-prefix-override-keys)
-                     (define-key keymap
-                                 (kbd prefix) #'sis--prefix-override-handler))
-                   keymap))))
-
        (setq sis--prefix-override-map-enable t)
-       (sis--prefix-override-recap-do)
+       (sis--prefix-override-install)
        (dolist (trigger sis-prefix-override-recap-triggers)
          (advice-add trigger :around
                      #'sis--prefix-override-recap-advice))
@@ -1138,9 +1095,7 @@ looked up as a whole, like the default `describe-key' behavior."
       (advice-remove trigger #'sis--respect-restore-advice))
 
     ;; for prefix key
-    (setq emulation-mode-map-alists
-          (delq 'sis--prefix-override-map-alist
-                emulation-mode-map-alists))
+    (sis--prefix-override-uninstall)
     (setq sis--prefix-override-map-enable nil)
     (dolist (trigger sis-prefix-override-recap-triggers)
       (advice-remove trigger #'sis--prefix-override-recap-advice))

--- a/sis.el
+++ b/sis.el
@@ -29,6 +29,10 @@
 ;;; Code:
 (require 'subr-x)
 
+(defgroup sis nil
+  "Smart input source."
+  :group 'convenience)
+
 (defvar sis-external-ism nil
   "Path of external ism.")
 
@@ -63,7 +67,9 @@ Default value is CJK characters and punctuations.")
 (defvar sis-auto-refresh-seconds 0.2
   "Idle timer interval to auto refresh input source status from OS.
 
-Emacs-nativ input method don't need it. nil to disable the timer.
+Emacs-native input methods do not need this timer; set this to nil to
+disable it.
+
 Set after the modes may have no effect.")
 
 (defvar sis-change-hook nil
@@ -250,7 +256,8 @@ custom function: the cursor will be moved to the end of the inline region, and
 (define-minor-mode sis-log-mode
   "Log the execution of this package."
   :global t
-  :init-value nil)
+  :init-value nil
+  :group 'sis)
 
 ;;
 ;; Following symbols are not supposed to be used directly by end user.
@@ -619,6 +626,7 @@ TYPE: TYPE can be \\='native, \\='w32, \\='emp, \\='macism, \\='im-select,
   "Automaticly refresh input source."
   :global t
   :init-value nil
+  :group 'sis
   (cond
    ;; turn on the mode
    (sis-auto-refresh-mode
@@ -696,6 +704,7 @@ way."
   "Automaticly change cursor color according to input source."
   :global t
   :init-value nil
+  :group 'sis
   (cond
    ;; turn on the mode
    (sis-global-cursor-color-mode
@@ -731,7 +740,7 @@ Possible values: \\='normal, \\='sequence.")
   "Current buffer before prefix.")
 
 (defvar sis--real-this-command nil
-  "Real this command. Some commands overwrite it.")
+  "Value of `this-command' before the current command runs.")
 
 (defvar sis--respect-post-cmd-timer nil
   "Timer to run after returning to command loop.")
@@ -829,8 +838,8 @@ Possible values: \\='normal, \\='sequence.")
 (defun sis--prefix-override-help-advice (fn &rest args)
   "Advice for FN reading or describing a key sequence with ARGS.
 
-The advice is needed, so that sequences like \\`C-x C-f' are read and
-looked up as a whole, like the default `describe-key' behavior."
+The advice makes key sequences read and looked up as a whole, matching
+the default `describe-key' behavior."
   (let ((sis--prefix-override-map-enable nil))
     (apply fn args)))
 
@@ -1024,6 +1033,7 @@ looked up as a whole, like the default `describe-key' behavior."
 - Respect buffer: restore buffer input source when it regain focus."
   :global t
   :init-value nil
+  :group 'sis
   (cond
    ;; turn on the mode
    (sis-global-respect-mode
@@ -1319,7 +1329,8 @@ If POSITION is not provided, then default to be the current position."
 (define-globalized-minor-mode
   sis-global-context-mode
   sis-context-mode
-  sis-context-mode)
+  sis-context-mode
+  :group 'sis)
 
 ;;;###autoload
 (defun sis-context ()
@@ -1371,7 +1382,8 @@ If POSITION is not provided, then default to be the current position."
 (define-globalized-minor-mode
   sis-global-inline-mode
   sis-inline-mode
-  sis-inline-mode)
+  sis-inline-mode
+  :group 'sis)
 
 (defsubst sis--evil-not-insert-state-p ()
   "In Evil but not at insert state."
@@ -1507,8 +1519,7 @@ START: start position of the inline region."
 
   ;; select input source
   (let* ((back-detect (sis--back-detect-chars))
-         (back-to (sis-back-detect-to back-detect))
-         (back-char (sis-back-detect-char back-detect)))
+         (back-to (sis-back-detect-to back-detect)))
     (cond
      ;;if in evil but not insert state
      ((sis--evil-not-insert-state-p)

--- a/sis.el
+++ b/sis.el
@@ -125,13 +125,6 @@ Set after the modes may have no effect.")
   (list "C-c" "C-x" "C-h" "C-r" "M-SPC")
   "Prefix keys to be overrided.")
 
-(defvar sis-prefix-override-recap-triggers
-  (list 'evil-local-mode 'yas-minor-mode)
-  "Commands trigger the recap of the prefix override.
-
-Some functions take precedence of the override, need to recap after.
-Set after the modes may have no effect.")
-
 (defvar sis-context-fixed nil
   "Context is fixed to a specific language in the /follow context mode/.
 
@@ -739,9 +732,6 @@ Possible values: \\='normal, \\='sequence.")
 (defvar sis--buffer-before-command nil
   "Current buffer before prefix.")
 
-(defvar sis--real-this-command nil
-  "Value of `this-command' before the current command runs.")
-
 (defvar sis--respect-post-cmd-timer nil
   "Timer to run after returning to command loop.")
 
@@ -822,27 +812,6 @@ Possible values: \\='normal, \\='sequence.")
     (define-key input-decode-map (car entry) (cdr entry)))
   (setq sis--prefix-override-saved-bindings nil))
 
-(defun sis--prefix-override-recap-do ()
-  "Recap prefix key override."
-  (sis--prefix-override-install))
-
-(defun sis--prefix-override-recap-advice (fn &rest args)
-  "Advice for FN of `prefix-override-recap-triggers' with ARGS."
-  (unwind-protect (apply fn args)
-    (sis--prefix-override-recap-do)))
-
-(defvar sis--prefix-override-help-fns
-  '(help--read-key-sequence describe-key describe-key-briefly)
-  "Functions advised to bypass the prefix override for key help.")
-
-(defun sis--prefix-override-help-advice (fn &rest args)
-  "Advice for FN reading or describing a key sequence with ARGS.
-
-The advice makes key sequences read and looked up as a whole, matching
-the default `describe-key' behavior."
-  (let ((sis--prefix-override-map-enable nil))
-    (apply fn args)))
-
 (defun sis--respect-focus-change-advice ()
   "Advice for `after-focus-change-function'."
   (if (frame-focus-state)
@@ -875,12 +844,11 @@ the default `describe-key' behavior."
 (defun sis--respect-pre-command-handler ()
   "Handler for `pre-command-hook' to preserve input source."
   (setq sis--buffer-before-command (current-buffer))
-  (setq sis--real-this-command this-command)
   (when sis-log-mode
     (message "pre@[%s]: [%s]@key [%s]@cmd [%s]@buf [%s]@override."
              sis--prefix-handle-stage
              (this-command-keys)
-             sis--real-this-command
+             this-command
              (current-buffer)
              sis--prefix-override-map-enable)))
 
@@ -915,7 +883,7 @@ the default `describe-key' behavior."
     (message "timer@[%s]: [%s]@key [%s]@cmd [%s]@buf [%s]@override."
              sis--prefix-handle-stage
              (this-command-keys)
-             sis--real-this-command
+             this-command
              (current-buffer)
              sis--prefix-override-map-enable))
 
@@ -951,8 +919,8 @@ the default `describe-key' behavior."
   (setq sis--prefix-handle-stage 'normal)
   (setq sis--respect-post-cmd-timer nil))
 
-(defsubst sis--to-normal-stage()
-  "Transite to normal stage."
+(defsubst sis--schedule-post-command-check ()
+  "Schedule respect-mode processing after the command loop settles."
   ;; for some command, after the command end,
   ;; the command loop may change the current buffer,
   ;; so delay the real processing.
@@ -962,12 +930,11 @@ the default `describe-key' behavior."
 
 (defun sis--respect-post-command-handler ()
   "Handler for `post-command-hook' to preserve input source."
-  ;; (setq this-command sis--real-this-command)
   (when sis-log-mode
     (message "post@[%s]: [%s]@key [%s]@cmd [%s]@buf [%s]@override."
              sis--prefix-handle-stage
              (this-command-keys)
-             sis--real-this-command
+             this-command
              (current-buffer)
              sis--prefix-override-map-enable))
   (pcase sis--prefix-handle-stage
@@ -977,10 +944,10 @@ the default `describe-key' behavior."
      (unless (minibufferp)
        (when sis-log-mode (message "Key sequence ended."))
        (setq sis--respect-force-restore t)
-       (sis--to-normal-stage)))
+       (sis--schedule-post-command-check)))
     ;; current is normal stage
     ('normal
-     (sis--to-normal-stage))))
+     (sis--schedule-post-command-check))))
 
 (defun sis--minibuffer-setup-handler ()
   "Handler for `minibuffer-setup-hook'."
@@ -1002,9 +969,7 @@ the default `describe-key' behavior."
   "Handler for `minibuffer-exit-hook'."
   (when sis-log-mode (message "exit minibuffer: [%s]@command" this-command))
   (setq sis--respect-force-restore t)
-  (unless sis--respect-post-cmd-timer
-    (setq sis--respect-post-cmd-timer
-          (run-with-timer 0 nil #'sis--respect-post-cmd-timer-fn))))
+  (sis--schedule-post-command-check))
 
 (defun sis--respect-evil ()
   "Respect evil."
@@ -1067,15 +1032,7 @@ the default `describe-key' behavior."
          (advice-add trigger :around #'sis--respect-restore-advice))
 
        (setq sis--prefix-override-map-enable t)
-       (sis--prefix-override-install)
-       (dolist (trigger sis-prefix-override-recap-triggers)
-         (advice-add trigger :around
-                     #'sis--prefix-override-recap-advice))
-
-       ;; keep default behavior when a command reads or describes a key
-       ;; sequence for help, e.g. `describe-key' (C-h k)
-       (dolist (fn sis--prefix-override-help-fns)
-         (advice-add fn :around #'sis--prefix-override-help-advice)))))
+       (sis--prefix-override-install))))
    ;; turn off the mode
    ((not sis-global-respect-mode)
     (sis--try-disable-auto-refresh-mode)
@@ -1106,11 +1063,7 @@ the default `describe-key' behavior."
 
     ;; for prefix key
     (sis--prefix-override-uninstall)
-    (setq sis--prefix-override-map-enable nil)
-    (dolist (trigger sis-prefix-override-recap-triggers)
-      (advice-remove trigger #'sis--prefix-override-recap-advice))
-    (dolist (fn sis--prefix-override-help-fns)
-      (advice-remove fn #'sis--prefix-override-help-advice)))))
+    (setq sis--prefix-override-map-enable nil))))
 
 (defun sis--try-disable-auto-refresh-mode ()
   "Try to disable auto refresh mode."


### PR DESCRIPTION
## Dependency

This is stacked on #93. Until #93 is merged, GitHub also shows its two commits
in this PR. The cleanup itself is commit `4cfd4d3`; relative to #93, it contains
10 insertions and 59 deletions across `sis.el` and the two README files.

## Cleanup

Once prefix keys are translated before keymap lookup by #93:

- Re-adding the SIS emulation map after Evil or Yasnippet changes maps is no
  longer necessary, so remove the recap variable, advice, and mode plumbing.
- `describe-key` receives the original key sequence directly, so remove the
  special help-function advice while retaining the behavior fixed by #92.
- `sis--real-this-command` has no functional consumer after the injected
  prefix command is gone; remove it and log `this-command` directly.
- Reuse the deferred post-command scheduler from minibuffer exit instead of
  duplicating the same timer guard and creation code.

No replacement abstraction or new option is introduced. The removed public
variable, `sis-prefix-override-recap-triggers`, controlled only the obsolete
emulation-map recapture path.

## Warning audit

#93 clears all source warnings inherited from master. This PR introduces no
new warning: all three CI jobs contain zero `sis.el` annotations. GitHub still
reports its Node.js 20 deprecation annotation for `actions/checkout@v2` and
`leotaku/elisp-check@master`; that is CI action runtime metadata, not an Emacs
Lisp source warning.

## Verification

- CI passes on Emacs 27.1, 28.2, and 29.4.
- 10 focused ERT checks pass, including interactive `describe-key`, a
  Meow-like emulation map added after prefix translations, reversible mode
  toggling, preservation of existing input-decode bindings, and timer
  deduplication.
- `checkdoc`, byte compilation with warnings treated as errors, source
  loading, `check-parens`, and `git diff --check` pass.
- In 500,000-iteration hot-path microbenchmarks, post-command scheduling and
  prefix translation remain within run-to-run noise, while removal of the
  extra pre-command assignment makes that path slightly faster.

Depends on #93.
