### PR TITLE
fix: require cl-lib for struct definitions

### DIFF
--- a/sis.el
+++ b/sis.el
@@ -27,6 +27,7 @@
 ;;For more information see the README in the GitHub repo.
 
 ;;; Code:
+(require 'cl-lib)
 (require 'subr-x)
 
 (defgroup sis nil


### PR DESCRIPTION
SIS uses `cl-defstruct` to define `sis-back-detect` and `sis-fore-detect`, but does not explicitly require `cl-lib`.

When SIS is byte-compiled in a clean Emacs environment, these forms may remain unexpanded in the generated bytecode. Loading that bytecode then fails with:

```
Symbol’s value as variable is void: sis-back-detect
```